### PR TITLE
[meta] Rename Coq -> Rocq in documentation files.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 
  - [build] [wasm] [code] bump esbuild from 0.16 to 0.25, miscellaneous
    npm dependencies bump (@ejgallego, #1033)
+ - [meta] Coq -> Rocq documentation rename (@ejgallego, #1034)
+ - [fleche] Support `\begin{rocq}` in literate Tex files (@ejgallego,
+   #1034)
 
 # coq-lsp 0.2.4: (W)Activation
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Github CI][ci-badge]][ci-link]
 
-`coq-lsp` is a [Language Server](https://microsoft.github.io/language-server-protocol/) for the [Rocq Prover](https://coq.inria.fr). It provides a single server that implements:
+`rocq-lsp` is a [Language Server](https://microsoft.github.io/language-server-protocol/) for the [Rocq Prover](https://rocq-prover.org/). It provides a single server that implements:
 
 - the [LSP](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/)
   protocol, with custom [extensions](./etc/doc/PROTOCOL.md)
@@ -11,13 +11,15 @@
 - the [MCP](https://modelcontextprotocol.io/) protocol (upcoming), an open
   protocol that standardizes how applications provide context to LLMs
 
-**Key [features](#Features)** of `coq-lsp` are: continuous, incremental document
+**☕ Try it online ☕**:  https://github.dev/ejgallego/hello-rocq
+
+**Key [features](#Features)** of `rocq-lsp` are: continuous, incremental document
 checking, real-time interruptions and limits, programmable error recovery,
 literate Markdown and LaTeX document support, multiple workspaces, positional
 goals, information panel, performance data, completion, jump to definition,
 extensible command-line compiler, a plugin system, and more.
 
-`coq-lsp` is built on **Flèche**, a new document checking engine for formal
+`rocq-lsp` is built on **Flèche**, a new document checking engine for formal
 documents based on our previous work on
 [SerAPI](https://github.com/ejgallego/coq-serapi/) and
 [jsCoq](https://github.com/jscoq/jscoq).
@@ -28,9 +30,9 @@ capabilities beyond standard Rocq.
 
 See the [User Manual](./etc/doc/USER_MANUAL.md) and the [General Documentation Index](./etc/doc/) for more details.
 
-This repository also includes the `coq-lsp` [Visual Studio
+This repository also includes the `rocq-lsp` [Visual Studio
 Code](https://code.visualstudio.com/) editor extension for the [Rocq Proof
-Assistant](https://coq.inria.fr), and a few other components. See our
+Assistant](https://rocq-prover.org/), and a few other components. See our
 [contributing guide](#contributing) for more information. Support
 for [Emacs](#emacs), [Vim](#vim) and [Neovim](#neovim) is also available in
 their own projects.
@@ -54,13 +56,9 @@ $ opam install coq-lsp && code --install-extension ejgallego.coq-lsp
     (rocq-mode . rocq-auto-goals-at-point-mode))
 ```
 
-  - **☕ Try it online ☕ (experimental)**:
-
-    https://github.dev/ejgallego/hello-rocq
-
   - **🪟 Windows:** (alternative method)
 
-    Download the [Coq Platform installer](#-server)
+    Download the [Rocq Platform installer](#-server)
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -81,14 +79,14 @@ $ opam install coq-lsp && code --install-extension ejgallego.coq-lsp
   - [🌐 Web Native!](#-web-native)
   - [🔎 A Platform for Research!](#-a-platform-for-research)
 - [🛠️ Installation](#️-installation)
-  - [🏘️ Supported Coq Versions](#️-supported-coq-versions)
+  - [🏘️ Supported Rocq (and Coq) Versions](#️-supported-rocq-versions)
   - [🏓 Server](#-server)
   - [🫐 Visual Studio Code](#-visual-studio-code)
   - [🦄 Emacs](#-emacs)
   - [✅ Vim](#-vim)
   - [🩱 Neovim](#-neovim)
   - [🐍 Python](#-python)
-- [⇨ `coq-lsp` users and extensions](#-coq-lsp-users-and-extensions)
+- [⇨ `rocq-lsp` users and extensions](#-rocq-lsp-users-and-extensions)
 - [🗣️ Discussion Channel](#️-discussion-channel)
 - [☎ Weekly Calls](#-weekly-calls)
 - [❓FAQ](#faq)
@@ -106,21 +104,21 @@ $ opam install coq-lsp && code --install-extension ejgallego.coq-lsp
 
 ### ⏩ Incremental Compilation and Continuous Document Checking
 
-Edit your file, and `coq-lsp` will try to re-check only what is necessary,
+Edit your file, and `rocq-lsp` will try to re-check only what is necessary,
 continuously. No more dreaded `Ctrl-C Ctrl-N`! Rechecking tries to be smart,
 and will ignore whitespace changes.
 
 <img alt="Incremental checking" height="286px" src="etc/img/lsp-incr.gif"/>
 
-In a future release, `coq-lsp` will save its document cache to disk, so you can
+In a future release, `rocq-lsp` will save its document cache to disk, so you can
 restart your proof session where you left it at the last time.
 
-Incremental support is undergoing refinement, if `coq-lsp` rechecks when it
+Incremental support is undergoing refinement, if `rocq-lsp` rechecks when it
 should not, please file a bug!
 
 ### 👁 On-demand, Follow The Viewport Document Checking
 
-`coq-lsp` does also support on-demand checking. Two modes are available: follow
+`rocq-lsp` does also support on-demand checking. Two modes are available: follow
 the cursor, or follow the viewport; the modes can be toggled using the Language
 Status Item in Code's bottom right corner:
 
@@ -128,22 +126,22 @@ Status Item in Code's bottom right corner:
 
 ### 🧠 Smart, Cache-Aware Error Recovery
 
-`coq-lsp` won't stop checking on errors, but supports (and encourages) working
+`rocq-lsp` won't stop checking on errors, but supports (and encourages) working
 with proof documents that are only partially working. Error recovery integrates
 with the incremental cache, and does recognize proof structure.
 
 You can edit without fear inside a `Proof. ... Qed.`, the rest of the document
 won't be rechecked; you can leave bullets and focused goals unfinished, and
-`coq-lsp` will automatically admit them for you.
+`rocq-lsp` will automatically admit them for you.
 
-If a lemma is not completed, `coq-lsp` will admit it automatically. No more
+If a lemma is not completed, `rocq-lsp` will admit it automatically. No more
 `Admitted` / `Qed` churn!
 
 <img alt="Smart error recovery" height="286px" src="etc/img/lsp-errors.gif"/>
 
 ### 🥅 Whole-Document Goal Display
 
-`coq-lsp` will follow the cursor movement and show underlying goals and
+`rocq-lsp` will follow the cursor movement and show underlying goals and
 messages; as well as information about what goals you have given up, shelves,
 pending obligations, open bullets and their goals.
 
@@ -155,19 +153,19 @@ more conservatively.
 ### 🗒️ Markdown and LaTeX Support
 
 Open a markdown file with a `.mv` extension, or a `TeX` file ending in `.lv` or
-`.v.tex`, then `coq-lsp` will check the code parts that are enclosed into `coq`
-language blocks! `coq-lsp` places human-friendly documents at the core of its
+`.v.tex`, then `rocq-lsp` will check the code parts that are enclosed into `rocq`
+language blocks! `rocq-lsp` places human-friendly documents at the core of its
 design ideas.
 
-<img alt="Coq + Markdown Editing" height="286px" src="etc/img/lsp-markdown.gif"/>
+<img alt="Rocq + Markdown Editing" height="286px" src="etc/img/lsp-markdown.gif"/>
 
 Moreover, you can use the usual Visual Studio Code Markdown or LaTeX preview
 facilities to render your markdown documents nicely!
 
 ### 👥 Document Outline
 
-`coq-lsp` supports document outline and code folding, allowing you to jump
-directly to definitions in the document. Many of the Coq vernacular commands
+`rocq-lsp` supports document outline and code folding, allowing you to jump
+directly to definitions in the document. Many of the Rocq vernacular commands
 like `Definition`, `Theorem`, `Lemma`, etc. will be recognized as document
 symbols which you can navigate to or see the outline of.
 
@@ -175,7 +173,7 @@ symbols which you can navigate to or see the outline of.
 
 ### 🐝 Document Hover
 
-Hovering over a Coq identifier will show its type.
+Hovering over a Rocq identifier will show its type.
 
 <img alt="Types on Hover" height="286px" src="etc/img/lsp-hover-2.gif"/>
 
@@ -184,77 +182,77 @@ preferences panel.
 
 ### 📁 Multiple Workspaces
 
-`coq-lsp` supports projects with multiple `_CoqProject` files, use the "Add
+`rocq-lsp` supports projects with multiple `_RocqProject` (or `_CoqProject`) files, use the "Add
 folder to Workspace" feature of Visual Studio code or the LSP Workspace Folders
 extension to use this in your project.
 
 ### 💾 `.vo` file saving
 
-`coq-lsp` can save a `.vo` file of the current document as soon as it the
+`rocq-lsp` can save a `.vo` file of the current document as soon as it the
 checking has been completed, using the command `Coq LSP: Save file to .vo`.
 
-You can configure `coq-lsp` in settings to do this every time you save your
+You can configure `rocq-lsp` in settings to do this every time you save your
 `.vo` file, but this can be costly so we ship it disabled by default.
 
 ### ⏱️ Detailed Timing and Memory Statistics
 
-Hover over any Coq sentence, `coq-lsp` will display detailed memory and timing
+Hover over any Rocq sentence, `rocq-lsp` will display detailed memory and timing
 statistics.
 
 <img alt="Stats on Hover" height="286px" src="etc/img/lsp-hover.gif"/>
 
 ### 🔧 Client-Side Configuration Options
 
-`coq-lsp` is configurable, and tries to adapt to your own workflow. What to do
+`rocq-lsp` is configurable, and tries to adapt to your own workflow. What to do
 when a proof doesn't check, admit or ignore? You decide!
 
-See the `coq-lsp` extension configuration in VSCode for options available.
+See the `rocq-lsp` extension configuration in VSCode for options available.
 
 <img alt="Configuration screen" height="286px" src="etc/img/lsp-config.png"/>
 
 ### 🖵 Extensible, Machine-friendly Command Line Compiler
 
-`coq-lsp` includes the `fcc` "Flèche Coq Compiler" which allows the access to
-almost all the features of Flèche / `coq-lsp` without the need to spawn a
+`rocq-lsp` includes the `fcc` "Flèche Coq Compiler" which allows the access to
+almost all the features of Flèche / `rocq-lsp` without the need to spawn a
 fully-fledged LSP client.
 
 `fcc` has been designed to be machine-friendly and extensible, so you can easily
 add your pre/post processing passes, for example to analyze or serialize parts
-of Coq files.
+of Rocq files.
 
-### 🪄 Advanced APIs for Coq Interaction
+### 🪄 Advanced APIs for Rocq Interaction
 
 Thanks to Flèche, we provide some APIs on top of it that allow advanced use
-cases with Coq. In particular, we provide direct, low-overhead access to Coq's
+cases with Rocq. In particular, we provide direct, low-overhead access to Rocq's
 proof engine using [petanque](./petanque).
 
 ### ♻️ Reusability, Standards, Modularity
 
-The incremental document checking library of `coq-lsp` has been designed to be
+The incremental document checking library of `rocq-lsp` has been designed to be
 reusable by other projects written in OCaml and with needs for document
-validation UI, as well as by other Coq projects such as jsCoq.
+validation UI, as well as by other Rocq projects such as jsCoq.
 
 Moreover, we are strongly based on standards, aiming for the least possible
 extensions.
 
 ### 🌐 Web Native!
 
-`coq-lsp` has been designed from the ground up to fully run inside your web
+`rocq-lsp` has been designed from the ground up to fully run inside your web
 browser seamlessly; our sister project, [jsCoq](https://github.com/jscoq/jscoq)
-has been already been experimentally ported to `coq-lsp`, and future releases
+has been already been ported to `rocq-lsp`, and future releases
 will use it by default.
 
-`coq-lsp` provides an exciting new array of opportunities for jsCoq, lifting
-some limitations we inherited from Coq's lack of web native support.
+`rocq-lsp` provides an exciting new array of opportunities for jsCoq, lifting
+some limitations we inherited from Rocq's lack of web native support.
 
 ### 🔎 A Platform for Research!
 
-A key `coq-lsp` goal is to serve as central platform for researchers in
+A key `rocq-lsp` goal is to serve as central platform for researchers in
 Human-Computer-Interaction, Machine Learning, and Software Engineering willing
-to interact with Coq.
+to interact with Rocq.
 
-Towards this goal, `coq-lsp` extends and is in the process of replacing [Coq
-SerAPI](https://github.com/ejgalleg/coqserapi), which has been used by many to
+Towards this goal, `rocq-lsp` extends and is in the process of replacing [Coq
+SerAPI](https://github.com/ejgalleg/coq-serapi), which has been used by many to
 that purpose.
 
 If you are a SerAPI user, please see our preliminary [migrating from
@@ -262,24 +260,24 @@ SerAPI](etc/SerAPI.md) document.
 
 ## 🛠️ Installation
 
-In order to use `coq-lsp` you'll need to install [**both**](etc/FAQ.md)
-`coq-lsp` and a suitable LSP client that understands `coq-lsp` extensions. The
+In order to use `rocq-lsp` you'll need to install [**both**](etc/FAQ.md)
+`rocq-lsp` and a suitable LSP client that understands `rocq-lsp` extensions. The
 recommended client is the Visual Studio Code Extension, but we aim to fully
 support other clients officially and will do so once their authors consider them
 ready.
 
-### 🏘️ Supported Coq Versions
+### 🏘️ Supported Rocq Versions
 
-`coq-lsp` supports Rocq 9.0, Coq 8.20, Coq 8.19, Coq 8.18, Coq 8.17, and Coq's
-`master` branch.  Code for each Coq version can be found in the corresponding
+`rocq-lsp` supports Rocq 9.1, Rocq 9.0, Coq 8.20, Coq 8.19, Coq 8.18, Coq 8.17, and Rocq's
+`master` branch.  Code for each Rocq version can be found in the corresponding
 branch.
 
-We recommended using Rocq 9.0 or `master` version. For other Coq versions, we
-recommend users to install the custom Coq tree as detailed in [Coq Upstream
-Bugs](#coq-upstream-bugs).
+We recommended using Rocq 9.1 or `master` version. For other Rocq versions, we
+recommend users to install the custom Rocq tree as detailed in [Rocq Upstream
+Bugs](#rocq-upstream-bugs).
 
 Note that this section covers user installs, if you would like to contribute to
-`coq-lsp` and build a development version, please check our [contributing
+`rocq-lsp` and build a development version, please check our [contributing
 guide](./CONTRIBUTING.md)
 
 ### 🏓 Server
@@ -290,14 +288,14 @@ guide](./CONTRIBUTING.md)
   ```
 - **Nix**:
   - In nixpkgs: [coqPackages.coq-lsp](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/coq-modules/coq-lsp)
-  - The `coq-lsp` server is automatically put in scope when running `nix-shell` in a
-    project using the [Coq Nix Toolbox](https://github.com/coq-community/coq-nix-toolbox)
+  - The `rocq-lsp` server is automatically put in scope when running `nix-shell` in a
+    project using the [Rocq Nix Toolbox](https://github.com/rocq-community/coq-nix-toolbox)
     (added to the toolbox Oct 10th 2023).
-  - An example of a `flake` that uses `coq-lsp` in a development environment is here
+  - An example of a `flake` that uses `rocq-lsp` in a development environment is here
      https://github.com/HoTT/Coq-HoTT/blob/master/flake.nix .
 - **Windows**:
-  Experimental Windows installers based on the [Coq
-  Platform](https://github.com/coq/platform) are available at https://www.irif.fr/~gallego/coq-lsp/
+  Experimental Windows installers based on the [Rocq
+  Platform](https://github.com/rocq-prover/platform) are available at https://www.irif.fr/~gallego/coq-lsp/
 
   This provides a Windows native binary that can be executed from VSCode
   normally. As of today a bit of configuration is still needed:
@@ -307,13 +305,13 @@ guide](./CONTRIBUTING.md)
     + `--coqlib=C:\Coq-Platform~8.20-lsp\lib\coq\`
     + `--coqcorelib=C:\Coq-Platform~8.20-lsp\lib\coq-core\`
     + `--ocamlpath=C:\Coq-Platform~8.20-lsp\lib\`
-  - Replace `C:\Coq-Platform~8.20-lsp\` by the path you have installed Coq above as needed
+  - Replace `C:\Coq-Platform~8.20-lsp\` by the path you have installed Rocq above as needed
   - Note that the installers are unsigned (for now), so you'll have to click on
     "More info" then "Run anyway" inside the "Windows Protected your PC" dialog
   - Also note that the installers are work in progress, and may change often.
 - **Do it yourself!** [Compilation from sources](./CONTRIBUTING.md#compilation)
 
-<!-- TODO 🟣 Emacs, 🪖 Proof general, 🐔 CoqIDE -->
+<!-- TODO 🟣 Emacs, 🪖 Proof general, 🐔 RocqIDE -->
 
 ### 🫐 Visual Studio Code
 
@@ -338,15 +336,15 @@ maintained by Josselin Poiret with contributions by Arthur Azevedo de Amorim.
 
 ### 🐍 Python
 
-- Interact programmatically with Coq files by using the [Coqpyt](https://github.com/sr-lab/coqpyt)
+- Interact programmatically with Rocq files by using the [Coqpyt](https://github.com/sr-lab/coqpyt)
   by Pedro Carrott and Nuno Saavedra.
 
-## ⇨ `coq-lsp` users and extensions
+## ⇨ `rocq-lsp` users and extensions
 
-The below projects are using `coq-lsp`, we recommend you try them!
+The below projects are using `rocq-lsp`, we recommend you try them!
 
-- [Coqpyt, a Python client for coq-lsp](https://github.com/sr-lab/coqpyt)
-- [CoqPilot uses Large Language Models to generate multiple potential proofs and then uses coq-lsp to typecheck them](https://github.com/JetBrains-Research/coqpilot).
+- [Coqpyt, a Python client for rocq-lsp](https://github.com/sr-lab/coqpyt)
+- [CoqPilot uses Large Language Models to generate multiple potential proofs and then uses rocq-lsp to typecheck them](https://github.com/JetBrains-Research/coqpilot).
 - [jsCoq: use Coq from your browser](https://github.com/jscoq/jscoq)
 - [Pytanque: a Python library implementing RL Environments](https://github.com/LLM4Coq/pytanque)
 - [ViZX: A Visualizer for the ZX Calculus](https://github.com/inQWIRE/ViZX).
@@ -355,14 +353,14 @@ The below projects are using `coq-lsp`, we recommend you try them!
 
 ## 🗣️ Discussion Channel
 
-`coq-lsp` discussion channel it at [Coq's
-Zulip](https://coq.zulipchat.com/#narrow/stream/329642-coq-lsp), don't hesitate
+`rocq-lsp` discussion channel it at [Rocq's
+Zulip](https://rocq-prover.zulipchat.com/#narrow/channel/329642-coq-lsp), don't hesitate
 to stop by; both users and developers are welcome.
 
 ## ☎ Weekly Calls
 
 We hold (almost) weekly video conference calls, see the [Call Schedule
-Page](https://github.com/ejgallego/coq-lsp/wiki/Coq-Lsp-Calls) for more
+Page](https://github.com/ejgallego/rocq-lsp/wiki/Rocq-Lsp-Calls) for more
 information. Everyone is most welcome!
 
 ## ❓FAQ
@@ -371,13 +369,15 @@ See our [list of frequently-asked questions](./etc/FAQ.md).
 
 ## ⁉️ Troubleshooting and Known Problems
 
-### Coq upstream bugs
+### Rocq upstream bugs
 
-Unfortunately Coq releases contain bugs that affect `coq-lsp`. We strongly
+Unfortunately Rocq releases contain bugs that affect `rocq-lsp`. We strongly
 recommend that if you are installing via opam, you use the following branches
 that have some fixes backported:
 
-- For 8.20: No known problems
+- For 9.1: No known critical problems
+- For 9.0: No known critical problems
+- For 8.20: No known critical problems
 - For 8.19: `opam pin add coq-core https://github.com/ejgallego/coq.git#v8.19+lsp`
 - For 8.18: `opam pin add coq-core https://github.com/ejgallego/coq.git#v8.18+lsp`
 - For 8.17: `opam pin add coq-core https://github.com/ejgallego/coq.git#v8.17+lsp`
@@ -387,17 +387,15 @@ that have some fixes backported:
 - Current rendering code can be slow with complex goals and messages, if that's
   the case, please open an issue and set the option `Coq LSP > Method to Print
   Coq Terms` to 0 as a workaround.
-- `coq-lsp` can fail to interrupt Coq in some cases, such as `Qed` or type class
+- `rocq-lsp` can fail to interrupt Coq in some cases, such as `Qed` or type class
   search. If that's the case, please open an issue, we have a experimental
   branch that solves this problem that you can try.
-- Working with multiple files in Coq < 8.17 requires a Coq patch, see below for
-  instructions.
-- If you install `coq-lsp/VSCode` simultaneously with the `VSCoq` Visual Studio
+- If you install `coq-lsp/VSCode` simultaneously with the `VSRocq` Visual Studio
   Code extension, Visual Studio Code gets confused and neither of them may
-  work. `coq-lsp` will warn about that. You can disable the `VSCoq` extension as
+  work. `rocq-lsp` will warn about that. You can disable the `VSRocq` extension as
   a workaround.
-- `_CoqProject` file parsing library will often `exit 1` on bad `_CoqProject`
-  files! There is little `coq-lsp` can do here, until upstream fixes this.
+- `_RocqProject` file parsing library will often `exit 1` on bad `_RocqProject`
+  files! There is little `rocq-lsp` can do here, until upstream fixes this.
 
 ### Troubleshooting
 
@@ -415,16 +413,16 @@ list of things we'd like to happen.
 
 ## 📕 Protocol Documentation
 
-`coq-lsp` mostly implements the [LSP
+`rocq-lsp` mostly implements the [LSP
 Standard](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/),
-plus some extensions specific to Coq.
+plus some extensions specific to Rocq.
 
-Check [the `coq-lsp` protocol documentation](etc/doc/PROTOCOL.md) for more details.
+Check [the `rocq-lsp` protocol documentation](etc/doc/PROTOCOL.md) for more details.
 
 ## 🤸 Contributing and Extending the System
 
 Contributions are very welcome! Feel free to chat with the dev team in
-[Zulip](https://coq.zulipchat.com/#narrow/stream/329642-coq-lsp) for any
+[Zulip](https://rocq-prover.zulipchat.com/#narrow/channel/329642-rocq-lsp) for any
 question, or just go ahead and hack.
 
 We have a [contributing guide](CONTRIBUTING.md), which includes a description of
@@ -432,11 +430,11 @@ the organization of the codebase, developer workflow, and more.
 
 Here is a [list of project ideas](etc/ContributionIdeas.md) that could be of
 help in case you are looking for contribution ideas, tho we are convinced that
-the best ideas will arise from using `coq-lsp` in your own Coq projects.
+the best ideas will arise from using `rocq-lsp` in your own Rocq projects.
 
-Both Flèche and `coq-lsp` have a preliminary _plugin system_. The VSCode
+Both Flèche and `rocq-lsp` have a preliminary _plugin system_. The VSCode
 extension also exports and API so other extensions use its functionality
-to query and interact with Coq documents.
+to query and interact with Rocq documents.
 
 ## 🥷 Team
 
@@ -456,7 +454,7 @@ The license for this project is LGPL 2.1 (or GPL 3+ as stated in the LGPL 2.1).
 - This server forked from our previous LSP implementation for the
   [Lambdapi](https://github.com/Deducteam/lambdapi) proof assistant, written by
   Emilio J. Gallego Arias, Frédéric Blanqui, Rodolphe Lepigre, and others; the
-  initial port to Coq was done by Emilio J. Gallego Arias and Vicent Laporte.
+  initial port to Rocq was done by Emilio J. Gallego Arias and Vicent Laporte.
 
 - `serlib`, `tests`, and goal processing components (among others) come from
   [SerAPI](https://github.com/rocq-archive/coq-serapi), and are under the same
@@ -476,10 +474,10 @@ The license for this project is LGPL 2.1 (or GPL 3+ as stated in the LGPL 2.1).
 Work on this server has been made possible thanks to many discussions,
 inspirations, and sharing of ideas from colleagues. In particular, we'd like to
 thank Rudi Grinberg, Andrey Mokhov, Clément Pit-Claudel, and Makarius Wenzel for
-their help and advice. Gaëtan Gilbert contributed many key and challenging Coq
-patches essential to `coq-lsp`; we also thank Guillaume Munch-Maccagnoni for his
+their help and advice. Gaëtan Gilbert contributed many key and challenging Rocq
+patches essential to `rocq-lsp`; we also thank Guillaume Munch-Maccagnoni for his
 [memprof-limits](https://guillaume.munch.name/software/ocaml/memprof-limits/index.html)
-library, which is essential to make `coq-lsp` on the real world, as well for
+library, which is essential to make `rocq-lsp` on the real world, as well for
 many advice w.r.t. OCaml.
 
 `rocq-lsp` includes several components and tests from
@@ -490,8 +488,8 @@ the SerAPI contributors.
 As noted above, the original implementation was based on the Lambdapi LSP
 server, thanks Frédéric Blanqui, Rodolphe Lepigre and all Lambdapi contributors.
 
-[ci-badge]: https://github.com/ejgallego/coq-lsp/actions/workflows/build.yml/badge.svg
-[ci-link]: https://github.com/ejgallego/coq-lsp/actions/workflows/build.yml
+[ci-badge]: https://github.com/ejgallego/rocq-lsp/actions/workflows/build.yml/badge.svg
+[ci-link]: https://github.com/ejgallego/rocq-lsp/actions/workflows/build.yml
 
 <!-- Local Variables: -->
 <!-- mode: Markdown -->

--- a/etc/FAQ.md
+++ b/etc/FAQ.md
@@ -1,14 +1,14 @@
-# `coq-lsp` frequently asked questions
+# `rocq-lsp` frequently asked questions
 
  * [Why do you say so often "client" and "server", what does it mean?](#why-do-you-say-so-often-client-and-server-what-does-it-mean)
- * [How is `coq-lsp` different from VSCoq?](#how-is-coq-lsp-different-from-vscoq)
-    + [VSCoq "Legacy"](#vscoq-legacy)
-    + [VSCoq 2](#vscoq-2)
- * [Is `coq-lsp` limited to VSCode?](#is-coq-lsp-limited-to-vscode)
- * [What part of the LSP protocol does `coq-lsp` support?](#what-part-of-the-lsp-protocol-does-coq-lsp-support)
- * [What is `coq-lsp` roadmap?](#what-is-coq-lsp-roadmap)
- * [How is `coq-lsp` developed and funded?](#how-is-coq-lsp-developed-and-funded)
- * [Is there more information about `coq-lsp` design?](#is-there-more-information-about-coq-lsp-design)
+ * [How is `rocq-lsp` different from VSRocq?](#how-is-rocq-lsp-different-from-vsrocq)
+    + [VSRocq "Legacy"](#vsrocq-legacy)
+    + [VSRocq 2](#vsrocq-2)
+ * [Is `rocq-lsp` limited to VSCode?](#is-rocq-lsp-limited-to-vscode)
+ * [What part of the LSP protocol does `rocq-lsp` support?](#what-part-of-the-lsp-protocol-does-rocq-lsp-support)
+ * [What is `rocq-lsp` roadmap?](#what-is-rocq-lsp-roadmap)
+ * [How is `rocq-lsp` developed and funded?](#how-is-rocq-lsp-developed-and-funded)
+ * [Is there more information about `rocq-lsp` design?](#is-there-more-information-about-rocq-lsp-design)
 
 ## Why do you say so often "client" and "server", what does it mean?
 
@@ -20,46 +20,46 @@ information, etc...
 
 This way, the editor don't need to know a lot about the language.
 
-Thus, in `coq-lsp` case we have:
+Thus, in `rocq-lsp` case we have:
 
-- the client is Visual Studio Code plus the `coq-lsp` extension, or
+- the client is Visual Studio Code plus the `rocq-lsp` extension, or
   some other editors such as Emacs or vim,
-- the server is an extended Coq binary `coq-lsp`, which takes care of
-  running and checking Coq commands, among other tasks.
+- the server is an extended Rocq binary `rocq-lsp`, which takes care of
+  running and checking Rocq commands, among other tasks.
 
 The client and the server communicate using the [Language Server
 Protocol](https://microsoft.github.io/language-server-protocol/)
-standard, thus, the `coq-lsp` language server can be used from any
+standard, thus, the `rocq-lsp` language server can be used from any
 editor supporting this protocol.
 
-## How is `coq-lsp` different from VSCoq?
+## How is `rocq-lsp` different from VSRocq?
 
-As of May 2025, two versions of VSCoq are available: VSCoq Legacy and
-VSCoq 2. They are independent implementations that share the same name
+As of May 2025, two versions of VSRocq are available: VSRocq Legacy and
+VSRocq 2. They are independent implementations that share the same name
 and project page.
 
-### VSCoq "Legacy"
+### VSRocq "Legacy"
 
-[VSCoq Legacy](https://github.com/coq-community/vscoq/tree/vscoq1) or
-"VSCoq 1" was developed by C. J. Bell, and later maintained by a team
-of volunteers at [coq-community](https://github.com/coq-community).
+[VSCoq Legacy](https://github.com/rocq-community/vscoq-legacy) or
+"VSRocq 1" was developed by C. J. Bell, and later maintained by a team
+of volunteers at [rocq-community](https://github.com/rocq-community).
 
-The key difference between "VSCoq 1" and `coq-lsp` / VSCoq 2 is how
+The key difference between "VSRocq 1" and `rocq-lsp` / VSRocq 2 is how
 the VS Code client communicates with Rocq.
 
-VSCoq 1 communicates with Rocq using the `coqidetop` server, which
+VSRocq 1 communicates with Rocq using the `coqidetop` server, which
 implements an XML protocol providing basic operations on documents.
 
-In the case of `coq-lsp`, VSCode and Rocq communicate using the LSP
+In the case of `rocq-lsp`, VSCode and Rocq communicate using the LSP
 protocol, plus a set of [custom extensions](./doc/PROTOCOL.md). This
-is possible thanks to a new `coq-lsp` language server, which is an
+is possible thanks to a new `rocq-lsp` language server, which is an
 extended Rocq binary taking advantage of improved Rocq APIs.
 
 The XML protocol design dates back to 2012, and it is not the best fit
-for modern editors. Also, the development of VSCoq 1 and `coqidetop`
+for modern editors. Also, the development of VSRocq 1 and `coqidetop`
 was not done in tandem, which required more coordination effort.
 
-VSCoq 1 made a significant effort to work with a vanilla XML
+VSRocq 1 made a significant effort to work with a vanilla XML
 protocol, but that came with its own set of technical and maintenance
 challenges.
 
@@ -67,81 +67,81 @@ A key problem in implementing a language server for Rocq is the fact
 that Rocq APIs were not meant for reactive User Interfaces.
 
 For `rocq-lsp`, we have made a years-long effort to significantly
-improve Coq's base APIs, which has resulted in a significantly lighter
+improve Rocq's base APIs, which has resulted in a significantly lighter
 client implementation and a more capable server.
 
-Moreover, `rocq-lsp` development is active while VSCoq 1 is mostly in
+Moreover, `rocq-lsp` development is active while VSRocq 1 is mostly in
 maintenance mode due to the limitations outlined above. In a sense,
-you could think of `coq-lsp` as a full rewrite of VSCoq 1, using the
+you could think of `rocq-lsp` as a full rewrite of VSRocq 1, using the
 experience we have accumulated over years of work in related projects
 (such as jsCoq, SerAPI, and Lambdapi), and the experience in
 state-of-the-art UI design and implementation in other systems (Rust,
 Lean, Isabelle).
 
-We didn't pick `VSCoq 2` as a project name given that `coq-lsp`
+We didn't pick `VSRocq 2` as a project name given that `rocq-lsp`
 follows the LSP standard and is not specific to Visual Studio Code, in
 fact, it works great on other editors such as vim or Emacs. The first
 public release of `rocq-lsp` was on November 2022. The original
 Lambdapi LSP server was written in 2017, and first ported to Rocq in
 early 2019.
 
-### VSCoq 2
+### VSRocq 2
 
-[VSCoq 2](https://github.com/coq-community/vscoq) follows the spirit
-of `coq-lsp` and uses an OCaml-based language server to provide an
+[VSRocq 2](https://github.com/rocq-prover/vsrocq) follows the spirit
+of `rocq-lsp` and uses an OCaml-based language server to provide an
 implementation of the Language Server Protocol for the Rocq Prover.
 
 The implementation approaches of both servers are very different.  We
 are working on a more detailed comparison between the projects. The
-first public release of VSCoq 2 happened in September 2023.
+first public release of VSRocq 2 happened in September 2023.
 
 We encourage you to try both and provide feedback!
 
-## Is `coq-lsp` limited to VSCode?
+## Is `rocq-lsp` limited to VSCode?
 
 No! See above!
 
 While VSCode is for now the primary client development platform,
-we fully intend the `coq-lsp` server to be usable from other editors.
+we fully intend the `rocq-lsp` server to be usable from other editors.
 
-In particular, we have already ported jsCoq to work as a `coq-lsp`
+In particular, we have already ported jsCoq to work as a `rocq-lsp`
 client.
 
 Please get in touch if you would like to contribute support for your
 favorite editor!
 
-## What part of the LSP protocol does `coq-lsp` support?
+## What part of the LSP protocol does `rocq-lsp` support?
 
-See the [PROTOCOL.md](./doc/PROTOCOL.md) file. `coq-lsp` provides some
-minimal extensions to the `coq-lsp` protocol as to adapt to the needs
+See the [PROTOCOL.md](./doc/PROTOCOL.md) file. `rocq-lsp` provides some
+minimal extensions to the `rocq-lsp` protocol as to adapt to the needs
 of interactive proof checking, see [this
 issue](https://github.com/microsoft/language-server-protocol/issues/1414)
 for more information about proof assistants and LSP.
 
-## What is `coq-lsp` roadmap?
+## What is `rocq-lsp` roadmap?
 
 The short-term roadmap is to support the full LSP protocol, and to
-focus on core issues related to the needs of Coq users.
+focus on core issues related to the needs of Rocq users.
 
 We follow a release model based on Semantic Versioning, see our bug
 tracker and project tracker for more information.
 
-## How is `coq-lsp` developed and funded?
+## How is `rocq-lsp` developed and funded?
 
-`coq-lsp` is developed collaboratively, by a [team of
-contributors](https://github.com/ejgallego/coq-lsp#team).
+`rocq-lsp` is developed collaboratively, by a [team of
+contributors](https://github.com/ejgallego/rocq-lsp#team).
 
 The development is coordinated by Emilio J. Gallego Arias, who is also
 the technical lead for the project.
 
-`coq-lsp` was supported by Inria Paris from November 2019 to October
+`rocq-lsp` was supported by Inria Paris from November 2019 to October
 2024, with key contributions by Ali Caglayan (volunteer) and Shachar
 Itzhaky (Technion Institute of Technology), and many other
 contributors.
 
 As of November 2024, the project is run on a volunteer basis.
 
-## Is there more information about `coq-lsp` design?
+## Is there more information about `rocq-lsp` design?
 
 Yes! There are a couple of presentations related to development
 methodology and internals. We will upload the presentations here

--- a/etc/SerAPI.md
+++ b/etc/SerAPI.md
@@ -1,36 +1,36 @@
-## Migrating from Coq SerAPI to `coq-lsp`
+## Migrating from Rocq SerAPI to `rocq-lsp`
 
 Welcome fellow SerAPI user, first of all, a reminder that is of
-crucial importance for us to keep maintaining both coq-lsp and
-Coq SerAPI: we need to hear from your use case.
+crucial importance for us to keep maintaining both rocq-lsp and
+Rocq SerAPI: we need to hear from your use case.
 
-Please, if you are using `coq-lsp` and / or SerAPI for research, open
+Please, if you are using `rocq-lsp` and / or SerAPI for research, open
 a pull request so we can link to your work in our readme.
 
 With that being said, here go a few notes on migrating from SerAPI to
-`coq-lsp`.
+`rocq-lsp`.
 
 ### Sexp vs JSONRpc
 
-`coq-lsp` is based on the Language Standard Protocol and uses JSON as
+`rocq-lsp` is based on the Language Standard Protocol and uses JSON as
 the main communication format. Several libraries exist to talk to LSP
 servers. The main difference, in addition to the format, and using a
-widespread standard for many operations, is that `coq-lsp` provides a
+widespread standard for many operations, is that `rocq-lsp` provides a
 _request_ and _notification_ RPC call.
 
 ### Add vs `didChange`
 
-`coq-lsp` does away with the "sentence" model underlying in SerAPI,
+`rocq-lsp` does away with the "sentence" model underlying in SerAPI,
 and now documents are understood as a whole. Document can contain
 markdown, images, JSON, and a variety of other data in addition to
-Coq.
+Rocq.
 
-`coq-lsp` understands incremental document checking, so clients just
+`rocq-lsp` understands incremental document checking, so clients just
 send the full document to it using the LSP notification `didChange`.
 
 In general, you don't want to worry about execution, being this the
-job of `coq-lsp`: you simply submit updated documents, and query for
-the info you need. `coq-lsp` will try to get back to you ASAP.
+job of `rocq-lsp`: you simply submit updated documents, and query for
+the info you need. `rocq-lsp` will try to get back to you ASAP.
 
 Parts of the document are identified using positions in the text
 buffer. This is much more flexible than the previous sentence-based
@@ -38,7 +38,7 @@ model.
 
 ### More on the new document engine, Flèche
 
-In general Flèche is much more capable than the previous coq-serapi
+In general Flèche is much more capable than the previous `coq-serapi`
 engine, in particular you can clone documents, execute speculatively,
 program your own error recovery strategies, etc... get in touch with
 us if you have any questions.
@@ -51,7 +51,7 @@ requests and methods. The common `(Query () Goals)` is now the
 
 ### Serialization format
 
-`coq-lsp` used JSON by default, but the underlying serializer is the
+`rocq-lsp` used JSON by default, but the underlying serializer is the
 same than we used in SerAPI. There is a very direct correspondence,
 but if you need, we can provide a SEXP compatibility layer for your
 needs, but often JSON produces better results due to OCaml records

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -1,14 +1,14 @@
-# coq-lsp protocol documentation
+# rocq-lsp protocol documentation
 
 ## Table of contents
 
 <!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
  - [Introduction and preliminaries](#introduction-and-preliminaries)
-    * [coq-lsp basic operating model](#coq-lsp-basic-operating-model)
-    * [coq-lsp workspace configuration](#coq-lsp-workspace-configuration)
+    * [`rocq-lsp` basic operating model](#rocq-lsp-basic-operating-model)
+    * [`rocq-lsp` workspace configuration](#rocq-lsp-workspace-configuration)
     * [A minimal client implementation:](#a-minimal-client-implementation)
  - [Language server protocol support table](#language-server-protocol-support-table)
-    * [URIs accepted by coq-lsp](#uris-accepted-by-coq-lsp)
+    * [URIs accepted by rocq-lsp](#uris-accepted-by-rocq-lsp)
  - [Implementation-specific options](#implementation-specific-options)
  - [Implementation-specific `data` error field](#implementation-specific-data-error-field)
  - [Extensions to the LSP specification](#extensions-to-the-lsp-specification)
@@ -45,7 +45,7 @@
 <!-- TOC --><a name="introduction-and-preliminaries"></a>
 ## Introduction and preliminaries
 
-`coq-lsp` is a Language Server Protocol implementation for the Rocq
+`rocq-lsp` is a Language Server Protocol implementation for the Rocq
 Prover. It is compatible with standard LSP clients but includes
 extensions for advanced Rocq-specific, machine-learning, and software
 engineering workflows, named `petanque`.
@@ -53,41 +53,41 @@ engineering workflows, named `petanque`.
 This document is written for the 3.17 version of the LSP specification:
 https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification
 
-For documentation on the API of the VSCode/VSCodium `coq-lsp`
+For documentation on the API of the VSCode/VSCodium `rocq-lsp`
 extension see the [VSCODE_API](./VSCODE_API.md) file instead.
 
 See also the upstream LSP issue on generic support for Proof
 Assistants
 https://github.com/microsoft/language-server-protocol/issues/1414
 
-<!-- TOC --><a name="coq-lsp-basic-operating-model"></a>
-### coq-lsp basic operating model
+<!-- TOC --><a name="rocq-lsp-basic-operating-model"></a>
+### rocq-lsp basic operating model
 
-`coq-lsp` is a bit different from other servers in that checking the
+`rocq-lsp` is a bit different from other servers in that checking the
 file is often very expensive, so the continuous LSP model can be too
-heavy. The philosophy of `coq-lsp` is to treat a Coq document as a
+heavy. The philosophy of `rocq-lsp` is to treat a Rocq document as a
 build task, and then check the document under user-request.
 
 Thus, for example when the user requests goals at a given point,
-`coq-lsp` will check if the goals are known, otherwise try to check
+`rocq-lsp` will check if the goals are known, otherwise try to check
 the required document parts to return answers to the user ASAP.
 
-`coq-lsp` has three main functioning modes (controlled by a regular
+`rocq-lsp` has three main functioning modes (controlled by a regular
 parameter):
 
-- _continuous mode_: in this mode, `coq-lsp` will try to complete
+- _continuous mode_: in this mode, `rocq-lsp` will try to complete
   checking of all open files when idle. This mode has shown to be very
   useful in many contexts, for example educational, as it provides
   very low latency.
 
-- _on-demand mode_: in this mode, `coq-lsp` will do nothing when
+- _on-demand mode_: in this mode, `rocq-lsp` will do nothing when
   idle. This mode, for example, can simulate the traditional
   "step-based" Rocq interaction mode, configure your client to request
-  goals at the desired position, and `coq-lsp` will execute the
+  goals at the desired position, and `rocq-lsp` will execute the
   document up to that point.
 
 - _on-demand mode, with viewport hints_: in this mode, inspired by
-  Isabelle, the `coq-lsp` client will inform the server about the
+  Isabelle, the `rocq-lsp` client will inform the server about the
   user's viewport. This mode provides a comfortable compromise between
   latency and CPU usage.
 
@@ -103,17 +103,18 @@ However, the underlying checking engine (`Flèche`) is very flexible,
 please feel free to contact with us if your client would want things
 in a different way.
 
-<!-- TOC --><a name="coq-lsp-workspace-configuration"></a>
-### coq-lsp workspace configuration
+<!-- TOC --><a name="rocq-lsp-workspace-configuration"></a>
+### rocq-lsp workspace configuration
 
-See the manual for the exact details. By default, `coq-lsp` attempts
-to auto-configure projects by locating `_CoqProject` files within the
-LSP workspace folders sent by the client.
+See the manual for the exact details. By default, `rocq-lsp` attempts
+to auto-configure projects by locating `_RocqProject` (or
+`_CoqProject`) files within the LSP workspace folders sent by the
+client.
 
 <!-- TOC --><a name="a-minimal-client-implementation"></a>
 ### A minimal client implementation:
 
-To implement a minimal but functional `coq-lsp` client, you need to:
+To implement a minimal but functional `rocq-lsp` client, you need to:
 
 - Initialize a standard LSP client.
 - Setup the right parameters for `initializationOptions` on `initialize`.
@@ -161,44 +162,44 @@ If a feature doesn't appear here it usually means it is not planned in the short
 | `textDocument/selectionRange`         | Partial | Selection for a point is its span; no parents                            |
 |---------------------------------------|---------|--------------------------------------------------------------------------|
 | `workspace/diagnostic`                | No      | Planned                                                                  |
-| `workspace/workspaceFolders`          | Yes     | Each folder should have a `_CoqProject` file at the root.                |
+| `workspace/workspaceFolders`          | Yes     | Each folder should have a `_RocqProject` file at the root.               |
 | `workspace/didChangeWorkspaceFolders` | Yes     |                                                                          |
 | `workspace/didChangeConfiguration`    | Yes (*) | We still do a client -> server push, instead of pull                     |
 |---------------------------------------|---------|--------------------------------------------------------------------------|
 
-<!-- TOC --><a name="uris-accepted-by-coq-lsp"></a>
-### URIs accepted by coq-lsp
+<!-- TOC --><a name="uris-accepted-by-rocq-lsp"></a>
+### URIs accepted by rocq-lsp
 
-The `coq-lsp` server only accepts `file:///` URIs; moreover, the URIs
-sent to the server must be able to be mapped back to a Coq library
+The `rocq-lsp` server only accepts `file:///` URIs; moreover, the URIs
+sent to the server must be able to be mapped back to a Rocq library
 name, so a fully-checked file can be saved to a `.vo` for example.
 
 Don't hesitate to open an issue if you need support for different kind
 of URIs in your application / client. The client does support
 `vsls:///` URIs.
 
-Additionally, `coq-lsp` will use the `languageId` field in `didOpen`
+Additionally, `rocq-lsp` will use the `languageId` field in `didOpen`
 parameters to determine the content type. Supported `languageId` are:
 - `coq` / `rocq`: File will be interpreted as a regular Rocq
   vernacular file,
 - `markdown`: File will be interpreted as a markdown file. Code
-  snippets between `coq` or `rocq` markdown code blocks will be
+  snippets between `rocq` (or `coq`) markdown code blocks will be
   interpreted as Rocq code.
 - `latex`: File will be interpreted as a LaTeX file. Code snippets
-  between `\begin{coq}/\end{coq}` LaTeX environments (or
-  `\being{rocq}/\end{rocq}` will be interpreted as Rocq code.
+  between `\begin{rocq}/\end{rocq}` LaTeX environments (or
+  `\being{coq}/\end{coq}` will be interpreted as Rocq code.
 
-By default, the `coq-lsp` VSCode client will activate for files ending
+By default, the `rocq-lsp` VSCode client will activate for files ending
 in some specific extensions, setting their `languageId` as follows:
 
-- `.v`: `languageId = coq`
+- `.v`: `languageId = rocq`
 - `.mv`: `languageId = markdown`
 - `.v.tex` or `.lv`: `languageId = latex`
 
 <!-- TOC --><a name="implementation-specific-options"></a>
 ## Implementation-specific options
 
-The `coq-lsp` server accepts several options via the
+The `rocq-lsp` server accepts several options via the
 `initializationOptions` field of the LSP initialize request. See
 `package.json` and the documentation of the
 `workspace/didChangeConfiguration` call below for the list of options.
@@ -228,7 +229,7 @@ interface RocqErrorData = {
 <!-- TOC --><a name="extensions-to-the-lsp-specification"></a>
 ## Extensions to the LSP specification
 
-As of today, `coq-lsp` implements several extensions to the LSP
+As of today, `rocq-lsp` implements several extensions to the LSP
 spec. Note that none of them are stable yet.
 
 - [Extra diagnostics data](#extra-diagnostics-data)
@@ -273,7 +274,7 @@ type DiagnosticsData = {
 <!-- TOC --><a name="goal-display"></a>
 ### Goal Display
 
-In order to display proof goals and information at point, `coq-lsp`
+In order to display proof goals and information at point, `rocq-lsp`
 supports the `proof/goals` request, parameters are:
 
 ```typescript
@@ -366,7 +367,7 @@ The main objects of interest are:
 - `Hyp`: This represents a pair of hypothesis names and type,
   additionally with a body as obtained with `set` or `pose` tactics
 
-- `Goal`: Contains a Coq goal: a pair of hypothesis and the goal's type
+- `Goal`: Contains a Rocq goal: a pair of hypothesis and the goal's type
 
 - `GoalConfig`: This is the main object for goals information, `goals`
   contains the current list of foreground goals, `stack` contains a
@@ -395,8 +396,8 @@ The main objects of interest are:
   - if `messages_follow_goal = true`, the selected sentence is the
     same than the one used for `goals`.
 
-An example for `stack` is the following Coq script:
-```coq
+An example for `stack` is the following Rocq script:
+```rocq
 t. (* Produces 5 goals *)
 - t1.
 - t2.
@@ -410,7 +411,7 @@ t. (* Produces 5 goals *)
 In this case, the stack will be `[ ["f1"], ["f3"] ; [ "t2"; "t1" ], [ "t4" ; "t5" ]]`.
 
 `proof/goals` was first used in the lambdapi-lsp server
-implementation, and we adapted it to `coq-lsp`.
+implementation, and we adapted it to `rocq-lsp`.
 
 <!-- TOC --><a name="selecting-an-output-format"></a>
 #### Selecting an output format
@@ -419,7 +420,7 @@ As of today, the _default_ output format type parameter `Pp` is
 controlled by the server option `pp_type : number`, if the `pp_format`
 field is not present. see `package.json` for different values. `0` is
 guaranteed to be `Pp = string`, the other values are
-Coq-implementation-specific and generally not stable; tho we provide
+Rocq-implementation-specific and generally not stable; tho we provide
 utils for those interested in richer printing formats.
 
 <!-- TOC --><a name="changelog"></a>
@@ -438,7 +439,7 @@ utils for those interested in richer printing formats.
 - v0.1.8: new optional `pretac` field for post-processing, backwards compatible with 0.1.7
 - v0.1.7: program information added, rest of fields compatible with 0.1.6
 - v0.1.7: pp_format field added to request, backwards compatible
-- v0.1.6: the `Pp` parameter can now be either Coq's `Pp.t` type or `string` (default)
+- v0.1.6: the `Pp` parameter can now be either Rocq's `Pp.t` type or `string` (default)
 - v0.1.5: message type does now include range and level
 - v0.1.4: goal type was made generic, the `stacks` and `def` fields are not null anymore, compatible v0.1.3 clients
 - v0.1.3: send full goal configuration with shelf, given_up, versioned identifier for document
@@ -538,10 +539,10 @@ const docReq : RequestType<FlecheDocumentParams, FlecheDocument, void>
 <!-- TOC --><a name="vo-file-saving"></a>
 ### .vo file saving
 
-Coq-lsp provides a file-save request `coq/saveVo`, which will save the
+rocq-lsp provides a file-save request `coq/saveVo`, which will save the
 current file to disk.
 
-Note that `coq-lsp` does not automatic trigger this on `didSave`, as
+Note that `rocq-lsp` does not automatic trigger this on `didSave`, as
 it would produce too much disk trashing, but we are happy to implement
 usability tweaks so `.vo` files are produced when they should.
 
@@ -697,7 +698,7 @@ client.
 ### Server Version Notification
 
 The server will send the `$/coq/serverVersion` notification to inform
-the client about `coq-lsp` version specific info.
+the client about `rocq-lsp` version specific info.
 
 The parameters are:
 ```typescript
@@ -743,7 +744,7 @@ export type CoqServerStatus = CoqBusyStatus | CoqIdleStatus;
 ### Sentence Execution Information
 
 The server will send the `$/coq/executionInformation` notification to
-inform the client that coq-lsp intends to execute a sentence.
+inform the client that rocq-lsp intends to execute a sentence.
 
 The parameters are:
 ```typescript
@@ -753,7 +754,7 @@ export type ExecutionInfoParams {
 };
 ```
 
-This way, clients can know when coq-lsp start execution of a sentence,
+This way, clients can know when rocq-lsp start execution of a sentence,
 and set a UI timer for example to inform the user that the sentence is
 under execution. This notification will likely be replaced by an
 improved `coq/fileProgress`.
@@ -789,8 +790,8 @@ Preliminary documentation for `pétanque` is provided below:
 <!-- TOC --><a name="changelog-8"></a>
 ### Changelog
 
-- v1 (coq-lsp 0.2.3): Initial public release
-- v2 (coq-lsp 0.2.4):
+- v1 (`rocq-lsp` 0.2.3): Initial public release
+- v2 (`rocq-lsp` 0.2.4):
   + **added**: new methods for Ast access
     [`petanque/ast`](#petanqueast) and
     [`petanque/ast_at_pos`](#petanqueastatpos) (@ejgallego, @JulesViennotFranca, #980)
@@ -942,7 +943,7 @@ interface Info =
 
 interface Premise =
     { full_name : string
-          /* should be a Coq DirPath, but let's go step by step */
+          /* should be a Rocq DirPath, but let's go step by step */
     ; file : string /* file (in FS format) where the premise is found */
     ; info : Result<Info, string> /* Info about the object, if available */
     }

--- a/etc/doc/README.md
+++ b/etc/doc/README.md
@@ -1,10 +1,10 @@
-# Welcome to `coq-lsp` documentation
+# Welcome to `rocq-lsp` documentation
 
 For now this is just a stub, we will add more information here
 soon. You can find some useful documents here:
 
-- `coq-lsp` core [README](../../README.md)
-- `coq-lsp` [contributing guide](../../CONTRIBUTING.md)
-- `coq-lsp` [User Manual](./USER_MANUAL.md)
-- [`coq-lsp` LSP Protocol Documentation](./PROTOCOL.md)
+- `rocq-lsp` core [README](../../README.md)
+- `rocq-lsp` [contributing guide](../../CONTRIBUTING.md)
+- `rocq-lsp` [User Manual](./USER_MANUAL.md)
+- [`rocq-lsp` LSP Protocol Documentation](./PROTOCOL.md)
 - [VSCode client API documentation](./VSCODE_API.md)

--- a/etc/doc/USER_MANUAL.md
+++ b/etc/doc/USER_MANUAL.md
@@ -1,70 +1,70 @@
-# `coq-lsp` user manual
+# `rocq-lsp` user manual
 
-Welcome to `coq-lsp` in-progress user-manual.
+Welcome to `rocq-lsp` in-progress user-manual.
 
-Please see also `coq-lsp` FAQ.
+Please see also `rocq-lsp` FAQ.
 
-## First steps with `coq-lsp`
+## First steps with `rocq-lsp`
 
-`coq-lsp` is designed to work on a project-basis, that is to say, the
+`rocq-lsp` is designed to work on a project-basis, that is to say, the
 user should point to the _root_ of their project (for example using
 "Open Folder" in VSCode).
 
-Given a project root `dir`, `coq-lsp` will try to read
+Given a project root `dir`, `rocq-lsp` will try to read
 `$dir/_RocqProject` (or `$dir/_CoqProject` if the first is not
 detected) and will apply the settings for your project from there.
 
-Other tools included in the `coq-lsp` suite usually take a
+Other tools included in the `rocq-lsp` suite usually take a
 `--root=dir` command line parameter to set this information up.
 
-`coq-lsp` will display information about the project root and setting
+`rocq-lsp` will display information about the project root and setting
 auto-detection using the standard language server protocol messaging
 facilities. In VSCode, these settings can be usually displayed in the
-"Output > Coq-lsp server" window.
+"Output > rocq-lsp server" window.
 
 ## Key features:
 
 ### Continuous vs on-demand mode
 
-`coq-lsp` offers two checking modes:
+`rocq-lsp` offers two checking modes:
 
-- continuous checking [default]: `coq-lsp` will check all your open
+- continuous checking [default]: `rocq-lsp` will check all your open
   documents eagerly. This is best when working with powerful machines
-  to minimize latency. When using OCaml 4.x, `coq-lsp` uses the
-  `memprof-limits` library to interrupt Coq and stay responsive.
+  to minimize latency. When using OCaml 4.x, `rocq-lsp` uses the
+  `memprof-limits` library to interrupt Rocq and stay responsive.
 
 - on-demand checking [set the `check_only_on_request` option]: In this
-  mode, `coq-lsp` will stay idle and only compute information that is
+  mode, `rocq-lsp` will stay idle and only compute information that is
   demanded, for example, when the user asks for goals. This mode
   disables some useful features such as `documentSymbol` as they can
   only be implemented by checking the full file.
 
   This mode can use the `check_on_scroll` option, which improves
-  latency by telling `coq-lsp` to check eagerly what is on view on
+  latency by telling `rocq-lsp` to check eagerly what is on view on
   user's screen.
 
 Users can change between on-demand/continuous mode by clicking on the
-"Coq language status" item in the bottom right corner for VSCode. We
+"Rocq language status" item in the bottom right corner for VSCode. We
 recommend pinning the language status item to see server status in
 real-time.
 
 ### Goal display
 
-By default, `coq-lsp` will follow cursor and show goals at cursor
+By default, `rocq-lsp` will follow cursor and show goals at cursor
 position. This can be tweaked in options.
 
-The `coq-lsp.sentenceNext` and `coq-lsp.sentencePrevious` commands will
-try to move the cursor one Coq sentence forward / backwards. These
+The `rocq-lsp.sentenceNext` and `rocq-lsp.sentencePrevious` commands will
+try to move the cursor one Rocq sentence forward / backwards. These
 commands are bound by default to `Alt + N` / `Alt + P` (`Cmd` on
 MacOS).
 
 ### Incremental proof edition
 
 Once you have setup your basic proof style, you may want to work with
-`coq-lsp` in a way that is friendly to incremental checking.
+`rocq-lsp` in a way that is friendly to incremental checking.
 
-For example, `coq-lsp` will recognize blocks of the form:
-```coq
+For example, `rocq-lsp` will recognize blocks of the form:
+```rocq
 Lemma foo : T.
 Proof.
  ...
@@ -76,11 +76,11 @@ re-checking what is outside.
 
 ### Error recovery
 
-`coq-lsp` can recover many errors automatically and allow you to
+`rocq-lsp` can recover many errors automatically and allow you to
 continue document edition later on.
 
 For example, it is not necessary to put `Admitted` in proofs that are
-not fully completed. Also, you can work with bullets and `coq-lsp`
+not fully completed. Also, you can work with bullets and `rocq-lsp`
 will automatically admit unfinished ones, so you can follow the
 natural proof structure.
 
@@ -90,18 +90,18 @@ natural proof structure.
 
 ### Embedded Markdown and LaTeX documents
 
-`coq-lsp` supports checking of TeX and Markdown document with embedded
-Coq inside. As of today, to enable this feature you must:
+`rocq-lsp` supports checking of TeX and Markdown document with embedded
+Rocq inside. As of today, to enable this feature you must:
 
-- **markdown**: open a file with `.mv` extension, `coq-lsp` will
+- **markdown**: open a file with `.mv` extension, `rocq-lsp` will
   recognize code blocks starting with ````coq` and ````rocq`.
-- **TeX**: open a file with `.lv` extension, `coq-lsp` will recognize
-  code blocks delimited by `\begin{coq} ... \end{coq}`
+- **TeX**: open a file with `.lv` extension, `rocq-lsp` will recognize
+  code blocks delimited by `\begin{rocq} ... \end{rocq}` and `\begin{coq} ... \end{coq}`.
 
 As of today, delimiters are expected at the beginning of the line,
 don't hesitate to request for further changes based on this feature.
 
-## Coq LSP Settings
+## Rocq LSP Settings
 
 ### Goal display
 
@@ -109,7 +109,7 @@ Several settings for goal display exist.
 
 ### Continuous vs on-demand mode:
 
-A setting to have `coq-lsp` check documents continuously exists.
+A setting to have `rocq-lsp` check documents continuously exists.
 
 ## Memory management
 
@@ -118,45 +118,45 @@ memory" command.
 
 ## Advanced: Multiple Workspaces
 
-`coq-lsp` does support projects that combine multiple Coq project
+`rocq-lsp` does support projects that combine multiple Rocq project
 roots in a single workspace. That way, one can develop on several
-distinct Coq developments seamlessly.
+distinct Rocq developments seamlessly.
 
 To enable this, use the "Add Folder" option in VSCode, where each root
-must be a folder containing a `_CoqProject` file.
+must be a folder containing a `_RocqProject` or `_CoqProject` file.
 
 Check the example at
 [../../examples/multiple_workspaces/](../../examples/multiple_workspaces/)
 to see it in action!
 
-## Interrupting coq-lsp
+## Interrupting rocq-lsp
 
-When a Coq document is being checked, it is often necessary to
+When a Rocq document is being checked, it is often necessary to
 _interrupt_ the checking process, for example, to check a new version,
 or to retrieve some user-facing information, such as goals.
 
-`coq-lsp` supports two different interruption methods, selectable at
+`rocq-lsp` supports two different interruption methods, selectable at
 start time via the `--int_backend` command-line parameter:
 
-- Coq-side polling (`--int_backend=Coq`, default for OCaml 5.x): in
-  this mode, Coq polls for a flag every once in a while, and will
+- Rocq-side polling (`--int_backend=Coq`, default for OCaml 5.x): in
+  this mode, Rocq polls for a flag every once in a while, and will
   raise an interruption when the flag is set. This method has the
-  downside that some paths in Coq don't check the flag often enough,
+  downside that some paths in Rocq don't check the flag often enough,
   for example, `Qed.`, so users may face unresponsiveness, as our
   server can only run one thread at a time.
 
 - `memprof-limits` token-based interruption (`--int_backend=Mp`,
-  experimental, default for OCaml 4.x): in this mode, Coq will use the
-  `memprof-limits` library to interrupt Coq.
+  experimental, default for OCaml 4.x): in this mode, Rocq will use the
+  `memprof-limits` library to interrupt Rocq.
 
-Coq has some bugs w.r.t. handling of asynchronous interruptions coming
-from `memprof-limits`. The situation is better in Coq 8.20, but users
-on Coq <= 8.19 do need to install a version of Coq with the backported
-fixes. See the information about Coq upstream bugs in the README for
+Rocq has some bugs w.r.t. handling of asynchronous interruptions coming
+from `memprof-limits`. The situation is better in Rocq 8.20, but users
+on Rocq <= 8.19 do need to install a version of Rocq with the backported
+fixes. See the information about Rocq upstream bugs in the README for
 more information about available branches.
 
-`coq-lsp` will reject to enable the new interruption mode by default
-on Coq < 8.20 unless the `lsp` Coq branch version is detected.
+`rocq-lsp` will reject to enable the new interruption mode by default
+on Rocq < 8.20 unless the `lsp` Rocq branch version is detected.
 
 ## Advanced incremental tricks
 
@@ -168,21 +168,21 @@ document after it use the state before the node `id` was found. Thus,
 any change between `$id` and the `Reset $id` command will not trigger
 a recheck of the rest of the document.
 
-```coq
-(* Coq code 1 *)
+```rocq
+(* Rocq code 1 *)
 
 Lemma foo : T.
 Proof. ... Qed.
 
-(* Coq code 2 *)
+(* Rocq code 2 *)
 
 Reset foo.
 
-(* Coq code 3 *)
+(* Rocq code 3 *)
 ```
 
-In the above code, any change in the "`Coq code 2`" section will not
-trigger a recheck of the "`Coq code 3`" Section, by virtue of the
+In the above code, any change in the "`Rocq code 2`" section will not
+trigger a recheck of the "`Rocq code 3`" Section, by virtue of the
 incremental engine.
 
 Using `Reset Initial`, you can effectively partition the document on

--- a/fleche/contents.ml
+++ b/fleche/contents.ml
@@ -70,8 +70,12 @@ module LaTeX = struct
     | [] -> []
     | l :: ls ->
       (* opening vs closing a markdown block *)
-      let code_marker = if coq then "\\end{coq}" else "\\begin{coq}" in
-      if String.equal code_marker l then gen l :: tex_map_lines (not coq) ls
+      let code_marker =
+        if coq then [ "\\end{rocq}"; "\\end{coq}" ]
+        else [ "\\begin{rocq}"; "\\begin{coq}" ]
+      in
+      let check l c = List.exists (String.equal c) l in
+      if check code_marker l then gen l :: tex_map_lines (not coq) ls
       else (if coq then l else gen l) :: tex_map_lines coq ls
 
   let process text =


### PR DESCRIPTION
Extension commands, binaries, and code will be done in 0.3, as they are not backwards compatible.

We also add support for `\begin{rocq}` in literate TeX mode.

cc: #933 